### PR TITLE
Replace np.float by float

### DIFF
--- a/mesh_hydro_utils/__init__.py
+++ b/mesh_hydro_utils/__init__.py
@@ -1,6 +1,4 @@
-"""
-
-"""
+""" """
 
 from .__version__ import __version__
 from .mesh_hydro_io import write_ic, read_output, read_ic, check_file_exists

--- a/mesh_hydro_utils/mesh_hydro_io.py
+++ b/mesh_hydro_utils/mesh_hydro_io.py
@@ -112,12 +112,12 @@ def read_output(fname):
 
     if ndim == 1:
         rho, u, p = np.loadtxt(
-            fname, usecols=[1, 2, 3], dtype=np.float, unpack=True, skiprows=linecount
+            fname, usecols=[1, 2, 3], dtype=float, unpack=True, skiprows=linecount
         )
 
     elif ndim == 2:
         rho, ux, uy, p = np.loadtxt(
-            fname, usecols=[2, 3, 4, 5], dtype=np.float, unpack=True, skiprows=linecount
+            fname, usecols=[2, 3, 4, 5], dtype=float, unpack=True, skiprows=linecount
         )
 
         rho = rho.reshape((nx, nx))
@@ -200,14 +200,14 @@ def _read_arbitrary_ic(fname):
             got_header = got_ftype and got_nx and got_ndim
             if got_header:
                 if ndim == 1:
-                    rho = np.empty((nx), dtype=np.float)
-                    u = np.empty((nx), dtype=np.float)
-                    p = np.empty((nx), dtype=np.float)
+                    rho = np.empty((nx), dtype=float)
+                    u = np.empty((nx), dtype=float)
+                    p = np.empty((nx), dtype=float)
 
                 elif ndim == 2:
-                    rho = np.empty((nx, nx), dtype=np.float)
-                    u = np.empty((nx, nx, 2), dtype=np.float)
-                    p = np.empty((nx, nx), dtype=np.float)
+                    rho = np.empty((nx, nx), dtype=float)
+                    u = np.empty((nx, nx, 2), dtype=float)
+                    p = np.empty((nx, nx), dtype=float)
 
         else:
             vals = _split_columns(clean)
@@ -315,9 +315,9 @@ def _read_twostate_ic(fname, nx):
 
     # now allocate rho, u, p arrays
 
-    rho = np.empty((nx), dtype=np.float)
-    u = np.empty((nx), dtype=np.float)
-    p = np.empty((nx), dtype=np.float)
+    rho = np.empty((nx), dtype=float)
+    u = np.empty((nx), dtype=float)
+    p = np.empty((nx), dtype=float)
 
     nxhalf = nx // 2
     rho[:nxhalf] = rhoL

--- a/mesh_hydro_utils/mesh_hydro_riemann.py
+++ b/mesh_hydro_utils/mesh_hydro_riemann.py
@@ -80,9 +80,9 @@ def riemann_solver(rho, u, p, t):
     if not is_vacuum:
         pstar, ustar = _find_star_state(rhoL, uL, pL, rhoR, uR, pR)
 
-    rho_sol = np.empty(rho.shape, dtype=np.float)
-    u_sol = np.empty(u.shape, dtype=np.float)
-    p_sol = np.empty(p.shape, dtype=np.float)
+    rho_sol = np.empty(rho.shape, dtype=float)
+    u_sol = np.empty(u.shape, dtype=float)
+    p_sol = np.empty(p.shape, dtype=float)
 
     center = (nx // 2) * dx  # position of the center
     for i in range(nx):


### PR DESCRIPTION
Since NumPy 2.0 or later, every time we use np.float will throw this error
```python
import numpy as np
np.float
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[2], line 1
----> 1 np.float

File /usr/lib/python3.12/site-packages/numpy/__init__.py:397, in __getattr__(attr)
    392     warnings.warn(
    393         f"In the future `np.{attr}` will be defined as the "
    394         "corresponding NumPy scalar.", FutureWarning, stacklevel=2)
    396 if attr in __former_attrs__:
--> 397     raise AttributeError(__former_attrs__[attr], name=None)
    399 if attr in __expired_attributes__:
    400     raise AttributeError(
    401         f"`np.{attr}` was removed in the NumPy 2.0 release. "
    402         f"{__expired_attributes__[attr]}",
    403         name=None
    404     )

AttributeError: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```